### PR TITLE
Updated Python version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ place).
 
 ## Installation
 
-Python 3.10 works fine.
+**⚠️ Python 3.13 is not currently supported. Use Python 3.10, 3.11, or 3.12 instead**
 
 Open a shell terminal and follow below steps:
 


### PR DESCRIPTION
Python 3.13 doesn't have pre-built packages yet, so pip tries to compile them from scratch which fails without the right tools. The packages that do install are mismatched versions that conflict with each other. Python 3.10-3.12 have all the pre-built stuff that works together. Use those instead.